### PR TITLE
Fix help command in shell for all commands

### DIFF
--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -170,7 +170,7 @@ func printHelp(cmds []string) {
 		cmd := strings.ToLower(args[0])
 
 		for _, c := range Commands {
-			if c.Name() == cmd {
+			if strings.ToLower(c.Name()) == cmd {
 				fmt.Printf("  %s\t# %s\n", c.Name(), c.Help())
 			}
 		}


### PR DESCRIPTION
# What problem are we solving?
help shell command is not working with upper-case letters:
- fs.mergeVolumes
- fs.meta.changeVolumeId
- s3.circuitBreaker
- volume.deleteEmpty
- ...


# How are we solving the problem?
check command name case-insensitively


# How is the PR tested?
Build and test manually


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
